### PR TITLE
Fix constructor of REST client

### DIFF
--- a/src/lib/TasklistRESTClient.ts
+++ b/src/lib/TasklistRESTClient.ts
@@ -33,8 +33,7 @@ export class TasklistRESTClient {
     } = {}) {
         this.oauthProvider = options.oauthProvider
         this.userAgentString = `tasklist-rest-client-nodejs/${pkg.version}`
-        const creds = getTasklistCredentials()
-        const baseUrl = options.baseUrl ?? `${creds.CAMUNDA_TASKLIST_BASE_URL}/v1`
+        const baseUrl = options.baseUrl ?? getTasklistCredentials().CAMUNDA_TASKLIST_BASE_URL
         this.rest = got.extend({
             prefixUrl: `${baseUrl}/${TASKLIST_API_VERSION}`
         })


### PR DESCRIPTION
Hello,

I'm Roman from [MyCubes](https://camunda.com/partners/my_cubes_b_v_/).

This PR eliminates the need to have credentials in environment when using REST client with both `baseUrl` and custom  `oauthProvider`. 