### PR TITLE
Fix type mismatches and some mistakes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export { TasklistApiClient } from "./lib/TasklistApiClient"
 export { TasklistRESTClient } from "./lib/TasklistRESTClient"
 
 export * from "./lib/Types"
+export * from "./lib/TypesREST"

--- a/src/lib/TasklistRESTClient.ts
+++ b/src/lib/TasklistRESTClient.ts
@@ -1,7 +1,7 @@
 import { OAuthProviderImpl, getTasklistToken } from "camunda-saas-oauth";
 import { getTasklistCredentials } from "camunda-8-credentials-from-env"
 import got from 'got';
-import { Form, Task, Variable } from "./Types";
+import { Form, Variable } from "./Types";
 import { REST } from "./TypesREST";
 import { encodeTaskVariablesForAPIRequest, JSONDoc } from "./utils";
  
@@ -68,7 +68,7 @@ export class TasklistRESTClient {
      * ```
      * @param query 
      */
-    public async getTasks(query: Partial<REST.TaskQuery>): Promise<Task[]> {
+    public async getTasks(query: Partial<REST.TaskQuery>): Promise<REST.Task[]> {
         const headers = await this.getHeaders()
         return this.rest.post('tasks/search', {
             json: query,
@@ -76,7 +76,7 @@ export class TasklistRESTClient {
         }).json()
     }
 
-    public async getAllTasks(): Promise<Task[]> {
+    public async getAllTasks(): Promise<REST.Task[]> {
         return this.getTasks({})
     }
 
@@ -86,9 +86,9 @@ export class TasklistRESTClient {
      * @param id 
      * @returns 
      */
-    public async getTask(taskId: string,): Promise<Task> {
+    public async getTask(taskId: string,): Promise<REST.Task> {
         const headers = await this.getHeaders()
-        return this.rest.get('tasks/${taskId}', {
+        return this.rest.get(`tasks/${taskId}`, {
             headers,
         }).json()   
     }
@@ -98,9 +98,9 @@ export class TasklistRESTClient {
      * @param formId 
      * @param processDefinitionKey 
      */
-    public async getForm(formId: string, processDefinitionKey: string): Promise<{form: Form}> {
+    public async getForm(formId: string, processDefinitionKey: string): Promise<Form> {
         const headers = await this.getHeaders()
-        return this.rest.get('forms/${formId}', {
+        return this.rest.get(`forms/${formId}`, {
             searchParams: {
                 processDefinitionKey
             },
@@ -117,7 +117,7 @@ export class TasklistRESTClient {
     public async getVariables(taskId: string, variableNames?: string[]): Promise<Variable[]> {
         const headers = await this.getHeaders()
         return this.rest.post(`tasks/${taskId}/variables/search`, {
-            body: JSON.stringify(variableNames || []),
+            body: JSON.stringify({ variableNames: variableNames || [] }),
             headers
         }).json()
     }
@@ -141,7 +141,7 @@ export class TasklistRESTClient {
      * @param allowOverrideAssignment 
      * @throws 400 - task not active, or already assigned. 403 - no permission to reassign task. 404 - no task for taskId.
      */
-    public async assignTask({taskId, allowOverrideAssignment = false, assignee}: {taskId: string, assignee?: string, allowOverrideAssignment?: boolean}): Promise<Task> {
+    public async assignTask({taskId, allowOverrideAssignment = false, assignee}: {taskId: string, assignee?: string, allowOverrideAssignment?: boolean}): Promise<REST.Task> {
         const headers = await this.getHeaders()
         return this.rest.patch(`tasks/${taskId}/assign`, {
             body: JSON.stringify({
@@ -157,7 +157,7 @@ export class TasklistRESTClient {
      * @param taskId 
      * @param variables 
      */
-    public async completeTask(taskId: string, variables?: JSONDoc): Promise<Task> {
+    public async completeTask(taskId: string, variables?: JSONDoc): Promise<REST.Task> {
         const headers = await this.getHeaders()
         return this.rest.patch(`tasks/${taskId}/complete`, {
             headers,
@@ -171,7 +171,7 @@ export class TasklistRESTClient {
      * @description Unassign a task with taskI
      * @param taskId 
      */
-    public async unassignTask(taskId: string): Promise<Task> {
+    public async unassignTask(taskId: string): Promise<REST.Task> {
         const headers = await this.getHeaders()
         return this.rest.patch(`tasks/${taskId}/unassign`, 
             {headers},

--- a/src/lib/TasklistRESTClient.ts
+++ b/src/lib/TasklistRESTClient.ts
@@ -1,7 +1,8 @@
 import { OAuthProviderImpl, getTasklistToken } from "camunda-saas-oauth";
 import { getTasklistCredentials } from "camunda-8-credentials-from-env"
 import got from 'got';
-import { Form, Task, TaskQuery, Variable } from "./Types";
+import { Form, Task, Variable } from "./Types";
+import { REST } from "./TypesREST";
 import { encodeTaskVariablesForAPIRequest, JSONDoc } from "./utils";
  
 const pkg = require('../../package.json')
@@ -67,7 +68,7 @@ export class TasklistRESTClient {
      * ```
      * @param query 
      */
-    public async getTasks(query: Partial<TaskQuery>): Promise<Task[]> {
+    public async getTasks(query: Partial<REST.TaskQuery>): Promise<Task[]> {
         const headers = await this.getHeaders()
         return this.rest.post('tasks/search', {
             json: query,

--- a/src/lib/TypesREST.ts
+++ b/src/lib/TypesREST.ts
@@ -1,0 +1,13 @@
+import { TaskQuery as TaskQueryQl } from "./Types";
+
+export namespace REST {
+    export enum TaskState {
+        CREATED,
+        COMPLETED,
+        CANCELED,
+    }
+
+    export interface TaskQuery extends Omit<TaskQueryQl, "state"> {
+        state: TaskState;
+    }
+}

--- a/src/lib/TypesREST.ts
+++ b/src/lib/TypesREST.ts
@@ -1,4 +1,4 @@
-import { TaskQuery as TaskQueryQl } from "./Types";
+import { TaskQuery as TaskQueryQl, Task as TaskQl } from "./Types";
 
 export namespace REST {
     export enum TaskState {
@@ -9,5 +9,20 @@ export namespace REST {
 
     export interface TaskQuery extends Omit<TaskQueryQl, "state"> {
         state: TaskState;
+    }
+
+    export interface Task
+        extends Omit<TaskQl, "processDefinitionId" | "processInstanceId" | "creationTime" | "completionTime"> {
+        processDefinitionKey: string;
+        processInstanceKey: string;
+        creationDate: string;
+        completionDate: string | null;
+        dueDate: string | null;
+        followUpDate: string | null;
+        candidateUsers: string[] | null;
+    }
+
+    export interface TaskWithVariables<T = { [key: string]: any }> extends Omit<Task, "variables"> {
+        variables: T;
     }
 }


### PR DESCRIPTION
Hello,

I'm Roman from [MyCubes](https://camunda.com/partners/my_cubes_b_v_/).

This PR fixes type mismatches and some simple but important typos and mistakes.

I used TypeScript namespace to keep same names of types while still have possibility export them from lib. Did not want to name it like `RTaskState` or `TaskStateRest` because then it doesn't match the [docs](https://docs.camunda.io/docs/8.2/apis-tools/tasklist-api-rest/schemas/enums/task-state/). This way I can use it like this:

```typescript
import { TasklistApiClient, REST } from 'camunda-tasklist-client'

const tasklist = new TasklistApiClient()

async function main() {
    const  tasks: REST.Task[] = await tasklist.getTasks({
        // now this works, regular "TaskState" - error 500 because it is object { value: 'CREATED', escape: false }
        state: REST.TaskState.CREATED
    })
    console.log(tasks);
}

main()
```